### PR TITLE
removed dependency on alias file

### DIFF
--- a/git-aware-terminal.bash
+++ b/git-aware-terminal.bash
@@ -36,7 +36,7 @@ find_git_branch() {
             branch_symbol=' ✇ '
         else
             # check remote branch exists
-            if [ ! `git b -r --list origin/${branch}` ]; then
+            if [ ! `git branch -r --list origin/${branch}` ]; then
                 branch_symbol='\033[38;5;160m ᚶ '
             else
                 branch_symbol=' ᚶ '


### PR DESCRIPTION
The original had a dependency on "git b" as a branch test... my setup uses the alias "git br" and so this failed. This patch makes "git branch" explicit and so removes the dependency on any particular alias.
